### PR TITLE
Feature/uninstall command

### DIFF
--- a/common/services/list.go
+++ b/common/services/list.go
@@ -1,4 +1,3 @@
-// common/services/list.go
 package services
 
 import (

--- a/common/services/uninstall.go
+++ b/common/services/uninstall.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
 func GetFgHome() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -16,11 +17,10 @@ func GetFgHome() string {
 	return filepath.Join(homeDir, ".fg")
 }
 
-func UninstallVersion(version string) error {
+func UninstallVersion(version string, force bool) error {
 	fgHome := GetFgHome()
 	
 	version = strings.TrimSpace(version)
-
 	versionPath := filepath.Join(fgHome, version)
 	
 	_, err := os.Stat(versionPath)
@@ -72,14 +72,16 @@ func UninstallVersion(version string) error {
 		}
 	}
 
-	fmt.Printf("Tem certeza que deseja desinstalar a versão %s? (s/N): ", version)
-	var response string
-	fmt.Scanln(&response)
-	response = strings.ToLower(strings.TrimSpace(response))
-	
-	if response != "s" && response != "sim" && response != "y" && response != "yes" {
-		fmt.Println("Desinstalação cancelada.")
-		return nil
+	if !force {
+		fmt.Printf("Tem certeza que deseja desinstalar a versão %s? (s/N): ", version)
+		var response string
+		fmt.Scanln(&response)
+		response = strings.ToLower(strings.TrimSpace(response))
+		
+		if response != "s" && response != "sim" && response != "y" && response != "yes" {
+			fmt.Println("Desinstalação cancelada.")
+			return nil
+		}
 	}
 	
 	err = os.RemoveAll(versionPath)
@@ -90,43 +92,11 @@ func UninstallVersion(version string) error {
 	fmt.Printf("Versão '%s' desinstalada com sucesso!\n", version)
 	return nil
 }
-func ListInstalledVersions() ([]string, error) {
-	fgHome := GetFgHome()
-	
-	_, err := os.Stat(fgHome)
-	if os.IsNotExist(err) {
-		return []string{}, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("erro ao verificar diretório principal: %v", err)
-	}
-	
-	entries, err := os.ReadDir(fgHome)
-	if err != nil {
-		return nil, fmt.Errorf("erro ao ler diretório principal: %v", err)
-	}
-	
-	versions := []string{}
-	for _, entry := range entries {
-		if entry.IsDir() {
 
-			name := entry.Name()
-			if strings.Contains(name, ".") && !strings.HasPrefix(name, ".") {
-				versions = append(versions, name)
-			}
-		}
-	}
-	
-	return versions, nil
-}
 var UninstallCmd = &cobra.Command{
 	Use:   "uninstall [versão]",
 	Short: "Desinstala uma versão",
-	Long: `Desinstala uma versão específica da aplicação.
-Isso remove o diretório completo da versão, incluindo todos os arquivos JAR e dados.
-
-Exemplo:
-  fg uninstall 1.0.0
-  fg uninstall 2.1.0`,
+	Long: `Desinstala uma versão específica da aplicação.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		version := args[0]
@@ -142,7 +112,7 @@ Exemplo:
 			fmt.Println("Modo força ativado: não será solicitada confirmação")
 		}
 		
-		err := UninstallVersion(version)
+		err := UninstallVersion(version, force)
 		if err != nil {
 			fmt.Println("Erro durante a desinstalação:", err)
 			return
@@ -150,52 +120,6 @@ Exemplo:
 	},
 }
 
-var uninstallListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Lista as versões instaladas",
-	Long: `Lista todas as versões atualmente instaladas no sistema.
-
-Exemplo:
-  fg uninstall list`,
-	Run: func(cmd *cobra.Command, args []string) {
-		versions, err := ListInstalledVersions()
-		if err != nil {
-			fmt.Println("Erro ao listar versões:", err)
-			return
-		}
-		
-		if len(versions) == 0 {
-			fmt.Println("Nenhuma versão instalada.")
-			return
-		}
-		
-		fmt.Println("Versões instaladas:")
-		for i, version := range versions {
-			fmt.Printf("%d. %s\n", i+1, version)
-
-			versionPath := filepath.Join(GetFgHome(), version)
-			jarCount := 0
-			
-			err := filepath.Walk(versionPath, func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return nil 
-				}
-				if !info.IsDir() && strings.HasSuffix(strings.ToLower(info.Name()), ".jar") {
-					jarCount++
-				}
-				return nil
-			})
-			
-			if err == nil && jarCount > 0 {
-				fmt.Printf("   Contém %d arquivo(s) JAR\n", jarCount)
-			}
-		}
-	},
-}
-
 func init() {
 	UninstallCmd.Flags().BoolP("force", "f", false, "Não solicitar confirmação para desinstalar")
-	
-	UninstallCmd.AddCommand(uninstallListCmd)
 }
-

--- a/common/services/uninstall.go
+++ b/common/services/uninstall.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 func GetFgHome() string {
 	homeDir, err := os.UserHomeDir()
@@ -87,5 +89,113 @@ func UninstallVersion(version string) error {
 	
 	fmt.Printf("Versão '%s' desinstalada com sucesso!\n", version)
 	return nil
+}
+func ListInstalledVersions() ([]string, error) {
+	fgHome := GetFgHome()
+	
+	_, err := os.Stat(fgHome)
+	if os.IsNotExist(err) {
+		return []string{}, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("erro ao verificar diretório principal: %v", err)
+	}
+	
+	entries, err := os.ReadDir(fgHome)
+	if err != nil {
+		return nil, fmt.Errorf("erro ao ler diretório principal: %v", err)
+	}
+	
+	versions := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+
+			name := entry.Name()
+			if strings.Contains(name, ".") && !strings.HasPrefix(name, ".") {
+				versions = append(versions, name)
+			}
+		}
+	}
+	
+	return versions, nil
+}
+var UninstallCmd = &cobra.Command{
+	Use:   "uninstall [versão]",
+	Short: "Desinstala uma versão",
+	Long: `Desinstala uma versão específica da aplicação.
+Isso remove o diretório completo da versão, incluindo todos os arquivos JAR e dados.
+
+Exemplo:
+  fg uninstall 1.0.0
+  fg uninstall 2.1.0`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		version := args[0]
+
+		fgHome := GetFgHome()
+		if _, err := os.Stat(fgHome); os.IsNotExist(err) {
+			fmt.Println("Nenhuma versão instalada. Diretório principal não existe.")
+			return
+		}
+
+		force, _ := cmd.Flags().GetBool("force")
+		if force {
+			fmt.Println("Modo força ativado: não será solicitada confirmação")
+		}
+		
+		err := UninstallVersion(version)
+		if err != nil {
+			fmt.Println("Erro durante a desinstalação:", err)
+			return
+		}
+	},
+}
+
+var uninstallListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lista as versões instaladas",
+	Long: `Lista todas as versões atualmente instaladas no sistema.
+
+Exemplo:
+  fg uninstall list`,
+	Run: func(cmd *cobra.Command, args []string) {
+		versions, err := ListInstalledVersions()
+		if err != nil {
+			fmt.Println("Erro ao listar versões:", err)
+			return
+		}
+		
+		if len(versions) == 0 {
+			fmt.Println("Nenhuma versão instalada.")
+			return
+		}
+		
+		fmt.Println("Versões instaladas:")
+		for i, version := range versions {
+			fmt.Printf("%d. %s\n", i+1, version)
+
+			versionPath := filepath.Join(GetFgHome(), version)
+			jarCount := 0
+			
+			err := filepath.Walk(versionPath, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return nil 
+				}
+				if !info.IsDir() && strings.HasSuffix(strings.ToLower(info.Name()), ".jar") {
+					jarCount++
+				}
+				return nil
+			})
+			
+			if err == nil && jarCount > 0 {
+				fmt.Printf("   Contém %d arquivo(s) JAR\n", jarCount)
+			}
+		}
+	},
+}
+
+func init() {
+	UninstallCmd.Flags().BoolP("force", "f", false, "Não solicitar confirmação para desinstalar")
+	
+	UninstallCmd.AddCommand(uninstallListCmd)
 }
 

--- a/common/services/uninstall.go
+++ b/common/services/uninstall.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+func GetFgHome() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "/tmp/fg"
+	}
+	return filepath.Join(homeDir, ".fg")
+}
+
+func UninstallVersion(version string) error {
+	fgHome := GetFgHome()
+	
+	version = strings.TrimSpace(version)
+
+	versionPath := filepath.Join(fgHome, version)
+	
+	_, err := os.Stat(versionPath)
+	if os.IsNotExist(err) {
+		entries, err := os.ReadDir(fgHome)
+		if err != nil {
+			return fmt.Errorf("erro ao ler diretório principal: %v", err)
+		}
+		
+		found := false
+		for _, entry := range entries {
+			if entry.IsDir() && strings.Contains(entry.Name(), version) {
+				versionPath = filepath.Join(fgHome, entry.Name())
+				version = entry.Name()
+				found = true
+				break
+			}
+		}
+		
+		if !found {
+			return fmt.Errorf("versão '%s' não encontrada", version)
+		}
+	} else if err != nil {
+		return fmt.Errorf("erro ao verificar versão: %v", err)
+	}
+	
+	fmt.Printf("Desinstalando versão: %s\n", version)
+	fmt.Printf("Localização: %s\n", versionPath)
+
+	jarFiles := []string{}
+	err = filepath.Walk(versionPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(strings.ToLower(info.Name()), ".jar") {
+			jarFiles = append(jarFiles, path)
+		}
+		return nil
+	})
+	
+	if err != nil {
+		return fmt.Errorf("erro ao procurar arquivos: %v", err)
+	}
+	
+	if len(jarFiles) > 0 {
+		fmt.Println("Arquivos JAR encontrados:")
+		for _, jar := range jarFiles {
+			fmt.Printf("  - %s\n", filepath.Base(jar))
+		}
+	}
+
+	fmt.Printf("Tem certeza que deseja desinstalar a versão %s? (s/N): ", version)
+	var response string
+	fmt.Scanln(&response)
+	response = strings.ToLower(strings.TrimSpace(response))
+	
+	if response != "s" && response != "sim" && response != "y" && response != "yes" {
+		fmt.Println("Desinstalação cancelada.")
+		return nil
+	}
+	
+	err = os.RemoveAll(versionPath)
+	if err != nil {
+		return fmt.Errorf("erro ao remover diretório: %v", err)
+	}
+	
+	fmt.Printf("Versão '%s' desinstalada com sucesso!\n", version)
+	return nil
+}
+


### PR DESCRIPTION
Foi adicionado a lógica para desinstalar a aplicação na máquina do usuário.Funcionalidades:
- Comando principal: 'fg uninstall [versão]' que remove uma versão específica
- Exibe os arquivos JAR que serão removidos antes da confirmação
- Flag: para pular a confirmação do usuário
- Validação da existência da versão antes de tentar desinstalar
- Gerencia corretamente o diretório em $HOME/.fg/[versão]